### PR TITLE
Upgrading cpr package to pickup permissions fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const extract = promisify(require('extract-zip'))
 const debug = require('debug')('download-chromium')
 const cpr = promisify(require('cpr'))
 const mkdirp = promisify(require('mkdirp'))
-const chmod = promisify(fs.chmod)
 
 const get = url => new Promise(resolve => https.get(url, resolve))
 
@@ -67,7 +66,6 @@ const copyCacheToModule = async (moduleExecutablePath, platform, revision) => {
     getFolderPath(cacheRoot, platform, revision),
     getFolderPath(__dirname, platform, revision)
   )
-  await chmod(moduleExecutablePath, '755')
 }
 
 module.exports = async (

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "download-chromium": "bin.js"
   },
   "dependencies": {
-    "cpr": "^2.2.0",
+    "cpr": "^3.0.1",
     "debug": "^3.0.1",
     "extract-zip": "^1.6.5",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
In version 3.0.0 cpr package was fixed to ensure permissions are maintained when copying files.
  see: https://github.com/davglass/cpr/commit/17b0494af1b173a30e82e0d8c69297f4376d6cbb)

--

I was getting permissions issues when attempting to run Chromium interactively. While investigating this, I found [a PR on the cpr package](https://github.com/davglass/cpr/pull/43) that ensures permissions are maintained when copying files. I tried upgrading download-chromium's dependency to cpr@3.0.1 and the permissions issues are now gone!