### PR TITLE
feat: emit download progress and allow changing installation path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .local-chromium
+.idea

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ download({
 	revision = '499413', 
 	log = false, 
 	onProgress = undefined, 
-	installPath = '{rootFolderOfThisModule}/.local-chromium' })
+	installPath = '{__dirname}/.local-chromium' })
 ```
 Returns a Promise resolving with the Chromium executable path.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ download({
 	revision = '499413', 
 	log = false, 
 	onProgress = undefined, 
-	installPath = '{root folder od download-chromium module}' })
+	installPath = '{rootFolderOfThisModule}/.local-chromium' })
 ```
 Returns a Promise resolving with the Chromium executable path.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ download({
 Returns a Promise resolving with the Chromium executable path.
 
 * use `installPath` if running from within `electron` packaged app (for example set install path to `require('electron').app.getPath('userData')`)
-* provide `onProgress` to track download progress. `onProgress` gets single argument: `{ percent, transferred: downloaded, total: downloadBodySize }` 
+* provide `onProgress` to track download progress. `onProgress` gets single argument: `{ percent, transferred, total }` 
 
 ## Kudos
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,19 @@ $ npm install download-chromium
 
 ## API
 
-### download({ platform = currentPlatform, revision = '499413', log = false })
-
+### download
+```
+download({ 
+	platform = currentPlatform, 
+	revision = '499413', 
+	log = false, 
+	onProgress = undefined, 
+	installPath = '{root folder od download-chromium module}' })
+```
 Returns a Promise resolving with the Chromium executable path.
+
+* use `installPath` if running from within `electron` packaged app (for example set install path to `require('electron').app.getPath('userData')`)
+* provide `onProgress` to track download progress. `onProgress` gets single argument: `{ percent, transferred: downloaded, total: downloadBodySize }` 
 
 ## Kudos
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ download({
 ```
 Returns a Promise resolving with the Chromium executable path.
 
-* use `installPath` if running from within `electron` packaged app (for example set install path to `require('electron').app.getPath('userData')`)
+* `installPath`: set the install path if you can't write your `node_modules`, eg from within an `electron` packaged app (`installPath: require('electron').app.getPath('userData')`)
 * provide `onProgress` to track download progress. `onProgress` gets single argument: `{ percent, transferred, total }` 
 
 ## Kudos

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ download({
 Returns a Promise resolving with the Chromium executable path.
 
 * `installPath`: set the install path if you can't write your `node_modules`, eg from within an `electron` packaged app (`installPath: require('electron').app.getPath('userData')`)
-* provide `onProgress` to track download progress. `onProgress` gets single argument: `{ percent, transferred, total }` 
+* `onProgress`: track download progress. `onProgress` receives one argument `{ percent, transferred, total }` 
 
 ## Kudos
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ download({
 ```
 Returns a Promise resolving with the Chromium executable path.
 
-* `installPath`: set the install path if you can't write your `node_modules`, eg from within an `electron` packaged app (`installPath: require('electron').app.getPath('userData')`)
+* `installPath`: set the install path if you can't write to your `node_modules`, eg from within an `electron` packaged app (`installPath: require('electron').app.getPath('userData')`)
 * `onProgress`: track download progress. `onProgress` receives one argument `{ percent, transferred, total }` 
 
 ## Kudos

--- a/bin.js
+++ b/bin.js
@@ -3,7 +3,17 @@
 
 const download = require('.')
 
-download({ log: true })
+function onPregress ({ percent, transferred, total }) {
+  console.log(
+    `progress: ${Math.round(
+      percent * 100
+    )}% (transferred ${transferred} out of ${total})`
+  )
+}
+download({
+  log: true,
+  onProgress: onPregress
+})
   .then(exec => console.log(exec))
   .catch(err => {
     console.error(err)

--- a/bin.js
+++ b/bin.js
@@ -12,7 +12,7 @@ function onProgress ({ percent, transferred, total }) {
 }
 download({
   log: true,
-  onProgress: onPregress
+  onProgress
 })
   .then(exec => console.log(exec))
   .catch(err => {

--- a/bin.js
+++ b/bin.js
@@ -3,7 +3,7 @@
 
 const download = require('.')
 
-function onPregress ({ percent, transferred, total }) {
+function onProgress ({ percent, transferred, total }) {
   console.log(
     `progress: ${Math.round(
       percent * 100

--- a/index.js
+++ b/index.js
@@ -18,10 +18,14 @@ const ProxyAgent = require('proxy-agent')
 
 // Windows archive name changed at r591479.
 const revisionChange = 591479
-const get = url => {
+const get = (url, onProgress) => {
   const proxy = getProxyForUrl(url)
   const agent = proxy ? new ProxyAgent(proxy) : undefined
-  return got.stream(url, { agent })
+  const result = got.stream(url, { agent });
+  if (onProgress) {
+    result.on('downloadProgress', onProgress)
+  }
+  return result;
 }
 
 const downloadURLs = {
@@ -61,7 +65,6 @@ const currentPlatform = (p => {
 
 const homePath = require('os').homedir()
 const cacheRoot = `${homePath}/.chromium-cache`
-const installPath = `${__dirname}/.local-chromium`
 
 const getFolderPath = (root, platform, revision) =>
   `${root}/chromium-${platform}-${revision}`
@@ -89,7 +92,7 @@ const getExecutablePath = (root, platform, revision) => {
  * - [x] copy and return
  */
 
-const copyCacheToModule = async (moduleExecutablePath, platform, revision) => {
+const copyCacheToModule = async (moduleExecutablePath, platform, revision, installPath) => {
   await mkdirp(getFolderPath(installPath, platform, revision))
   await cpr(
     getFolderPath(cacheRoot, platform, revision),
@@ -98,10 +101,13 @@ const copyCacheToModule = async (moduleExecutablePath, platform, revision) => {
 }
 
 module.exports = async ({
-  platform: platform = currentPlatform,
-  revision: revision = '499413',
-  log: log = false
-} = {}) => {
+                          platform: platform = currentPlatform,
+                          revision: revision = '499413',
+                          log: log = false,
+                          installPath: installPathBase = __dirname,
+                          onProgress: onProgress
+                        } = {}) => {
+  const installPath = `${installPathBase}/.local-chromium`
   const moduleExecutablePath = getExecutablePath(
     installPath,
     platform,
@@ -123,7 +129,7 @@ module.exports = async ({
 
   if (exists) {
     debug('copy cache to module')
-    await copyCacheToModule(moduleExecutablePath, platform, revision)
+    await copyCacheToModule(moduleExecutablePath, platform, revision, installPath)
     return moduleExecutablePath
   }
 
@@ -140,7 +146,7 @@ module.exports = async ({
   if (log) process.stderr.write(`Downloading Chromium r${revision}...`)
   debug('download')
   await pipe(
-    await get(url),
+    await get(url, onProgress),
     fs.createWriteStream(zipPath)
   )
 
@@ -151,7 +157,7 @@ module.exports = async ({
   await unlink(zipPath)
 
   debug('copy cache to module')
-  await copyCacheToModule(moduleExecutablePath, platform, revision)
+  await copyCacheToModule(moduleExecutablePath, platform, revision, installPath)
 
   if (log) process.stderr.write('Done!\n')
   return moduleExecutablePath

--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ const revisionChange = 591479
 const get = (url, onProgress) => {
   const proxy = getProxyForUrl(url)
   const agent = proxy ? new ProxyAgent(proxy) : undefined
-  const result = got.stream(url, { agent });
+  const result = got.stream(url, { agent })
   if (onProgress) {
     result.on('downloadProgress', onProgress)
   }
-  return result;
+  return result
 }
 
 const downloadURLs = {
@@ -92,7 +92,12 @@ const getExecutablePath = (root, platform, revision) => {
  * - [x] copy and return
  */
 
-const copyCacheToModule = async (moduleExecutablePath, platform, revision, installPath) => {
+const copyCacheToModule = async (
+  moduleExecutablePath,
+  platform,
+  revision,
+  installPath
+) => {
   await mkdirp(getFolderPath(installPath, platform, revision))
   await cpr(
     getFolderPath(cacheRoot, platform, revision),
@@ -101,13 +106,12 @@ const copyCacheToModule = async (moduleExecutablePath, platform, revision, insta
 }
 
 module.exports = async ({
-                          platform: platform = currentPlatform,
-                          revision: revision = '499413',
-                          log: log = false,
-                          installPath: installPathBase = __dirname,
-                          onProgress: onProgress
-                        } = {}) => {
-  const installPath = `${installPathBase}/.local-chromium`
+  platform: platform = currentPlatform,
+  revision: revision = '499413',
+  log: log = false,
+  installPath: installPath = `${__dirname}/.local-chromium`,
+  onProgress
+} = {}) => {
   const moduleExecutablePath = getExecutablePath(
     installPath,
     platform,
@@ -129,7 +133,12 @@ module.exports = async ({
 
   if (exists) {
     debug('copy cache to module')
-    await copyCacheToModule(moduleExecutablePath, platform, revision, installPath)
+    await copyCacheToModule(
+      moduleExecutablePath,
+      platform,
+      revision,
+      installPath
+    )
     return moduleExecutablePath
   }
 


### PR DESCRIPTION
Hi @juliangruber thanks for creating this library. This PR was created to support packaged application like electron where the node_modules is bundled and compressed and it is not possible for a library to simply download to its' root.

# Goals
## customize installation path
I added a new option named `installPath` which default to `__dirname` to be backward compatible. I also updated the `readme.md` file with a suggestion about relevant value if using electron to pack this library.

## report download progress
As applications might want to show download progress I propagated the `onProgress` event from `got` library thru the options. This is optional and will work also if the user choose not to monitor the progress.