### PR TITLE
Update `getFolderPath` - remove `chromium-` prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ const currentPlatform = (p => {
 
 const cacheRoot = `${os.homedir()}/.chromium-cache`
 const getFolderPath = (root, platform, revision) =>
-  `${root}/chromium-${platform}-${revision}`
+  `${root}/${platform}-${revision}`
 
 const getExecutablePath = (root, platform, revision) => {
   const folder = getFolderPath(root, platform, revision)


### PR DESCRIPTION
If you'd like to do this yourself while the PR is not merged yet, you can use https://github.com/ds300/patch-package

---

Previously, until doing this, I got an error:

```console
(node:88438) UnhandledPromiseRejectionWarning: Error: Failed to launch chrome! spawn /home/kipras/privateprojects/snitch-latest-car/package/puppeteer/linux-706915/chrome-linux/chrome ENOENT


TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

    at onClose (/snapshot/snitch-latest-car-master/node_modules/puppeteer/lib/Launcher.js:348:14)
    at ChildProcess.<anonymous> (/snapshot/snitch-latest-car-master/node_modules/puppeteer/lib/Launcher.js:339:64)
    at ChildProcess.emit (events.js:210:5)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:270:12)
    at onErrorNT (internal/child_process.js:456:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
(node:88438) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:88438) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

when using puppeteer (`2.0.0`).

After applying this patch, everything works!

Note - please test this out yourself before merging - this probably will be a breaking change..